### PR TITLE
doc: Update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,19 @@ Proxy that provides access to the VNC console of a Kubevirt VM.
 
 It can generate time limited tokens that are then used to access VNC.
 
+## Installation
+
+### With SSP operator
+The [SSP operator](https://github.com/kubevirt/ssp-operator) can be configured to install the VM Console Proxy together with
+a Route to expose it to the external network.
+
+### Without SSP operator
+VM Console Proxy needs to be deployed in the same namespace as KubeVirt.
+To deploy the latest version, use the following command:
+```bash
+kubectl apply -n ${KUBEVIRT_NAMESPACE} -f "https://github.com/kubevirt/vm-console-proxy/releases/latest/download/vm-console-proxy.yaml"
+```
+
 ## API
 See the [API documentation](docs/api.md).
 

--- a/example-client/README.md
+++ b/example-client/README.md
@@ -18,3 +18,6 @@ For example, the following URL will point the client to a VM after substituting 
 ```
 http://localhost:8000/?host=vm-console-kubevirt.apps-crc.testing&namespace=${VM_NAMESPACE}&name=${VM_NAME}&token=${TOKEN}
 ```
+
+**Note:** If the browser does not trust the TLS certificate from the cluster, only a generic
+error message will be shown, that does not contain any reason for the failure.


### PR DESCRIPTION
**What this PR does / why we need it**:
- Added installation instructions.
- Added note into example-client documentation to remind the user that browser needs to trust the TLS certificate from the cluster.

**Release note**:
```release-note
None
```
