### PR TITLE
fix: Do not mount virt-handler certificates to pod

### DIFF
--- a/manifests/deployment.yaml
+++ b/manifests/deployment.yaml
@@ -44,9 +44,6 @@ spec:
             - name: "vm-console-proxy-cert"
               mountPath: "/tmp/vm-console-proxy-cert"
               readOnly: true
-            - name: "kubevirt-virt-handler-certs"
-              mountPath: "/etc/virt-handler/clientcertificates"
-              readOnly: true
       terminationGracePeriodSeconds: 10
       volumes:
         - name: "config"
@@ -55,6 +52,3 @@ spec:
         - name: "vm-console-proxy-cert"
           secret:
             secretName: "vm-console-proxy-cert"
-        - name: "kubevirt-virt-handler-certs"
-          secret:
-            secretName: "kubevirt-virt-handler-certs"


### PR DESCRIPTION
The certificates are not needed, because the pod no longer connects directly to virt-handler.

**Release note**:
```release-note
None
```
