### PR TITLE
fix: Do not send an error message for authentication failure

### DIFF
--- a/pkg/console/service/service.go
+++ b/pkg/console/service/service.go
@@ -56,13 +56,13 @@ func (s *service) TokenHandler(request *restful.Request, response *restful.Respo
 
 	authToken := getAuthToken(request)
 	if authToken == "" {
-		_ = response.WriteError(http.StatusUnauthorized, fmt.Errorf("authenticating token cannot be empty"))
+		_ = response.WriteError(http.StatusUnauthorized, nil)
 		return
 	}
 
 	err = s.checkVncRbac(request.Request.Context(), authToken, params.name, params.namespace)
 	if err != nil {
-		_ = response.WriteError(http.StatusUnauthorized, err)
+		_ = response.WriteError(http.StatusUnauthorized, nil)
 		return
 	}
 

--- a/pkg/console/service/service_test.go
+++ b/pkg/console/service/service_test.go
@@ -147,7 +147,7 @@ var _ = Describe("Service", func() {
 		testService.TokenHandler(request, response)
 
 		Expect(recorder.Code).To(Equal(http.StatusUnauthorized))
-		Expect(recorder.Body.String()).To(Equal("authenticating token cannot be empty"))
+		Expect(recorder.Body.String()).To(BeEmpty())
 	})
 
 	It("should fail if Authorization header is not Bearer", func() {
@@ -156,7 +156,7 @@ var _ = Describe("Service", func() {
 		testService.TokenHandler(request, response)
 
 		Expect(recorder.Code).To(Equal(http.StatusUnauthorized))
-		Expect(recorder.Body.String()).To(Equal("authenticating token cannot be empty"))
+		Expect(recorder.Body.String()).To(BeEmpty())
 	})
 
 	It("should fail if authorization token is invalid", func() {
@@ -170,7 +170,7 @@ var _ = Describe("Service", func() {
 		testService.TokenHandler(request, response)
 
 		Expect(recorder.Code).To(Equal(http.StatusUnauthorized))
-		Expect(recorder.Body.String()).To(Equal("token is not authenticated"))
+		Expect(recorder.Body.String()).To(BeEmpty())
 	})
 
 	It("should fail if authorization token does not have permission to access virtualmachineinstances/vnc", func() {
@@ -184,7 +184,7 @@ var _ = Describe("Service", func() {
 		testService.TokenHandler(request, response)
 
 		Expect(recorder.Code).To(Equal(http.StatusUnauthorized))
-		Expect(recorder.Body.String()).To(ContainSubstring("does not have permission to access virtualmachineinstances/vnc endpoint"))
+		Expect(recorder.Body.String()).To(BeEmpty())
 	})
 
 	It("should pass user info from TokenReview to SubjectAccessReview", func() {

--- a/tests/proxy_test.go
+++ b/tests/proxy_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Kubevirt proxy", func() {
 			code, body, err := httpGet(tokenUrl, "", TestHttpClient)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(code).To(Equal(http.StatusUnauthorized))
-			Expect(string(body)).To(ContainSubstring("authenticating token cannot be empty"))
+			Expect(string(body)).To(BeEmpty())
 		})
 
 		It("should fail if not authorized to access vmi/vnc endpoint", func() {
@@ -74,7 +74,7 @@ var _ = Describe("Kubevirt proxy", func() {
 			code, body, err := httpGet(tokenUrl, saToken, TestHttpClient)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(code).To(Equal(http.StatusUnauthorized))
-			Expect(string(body)).To(ContainSubstring("does not have permission to access virtualmachineinstances/vnc endpoint"))
+			Expect(string(body)).To(BeEmpty())
 		})
 
 		It("should fail if VM does not exist", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
When a request fails authentication, no message with reason is sent back.

Fixes part of #20 
Jira link: https://issues.redhat.com/browse/CNV-31223

**Release note**:
```release-note
Authentication failures do not send back a detailed error message.
```
