### PR TITLE
fix: example-client: Token in subprotocol needs to be in base64

### DIFF
--- a/example-client/README.md
+++ b/example-client/README.md
@@ -1,9 +1,7 @@
 # Example VNC client
 
-**This example client currently does not work. It will be fixed in the future.**
-
 This directory contains an example page that uses noVNC library
-to connect to the `vn-console-proxy` running on a cluster.
+to connect to the `VMI/vnc` endpoint using a token. 
 
 A simple server with this page can be started by:
 ```bash
@@ -15,7 +13,7 @@ The client page takes these URL parameters:
 - `port` - Port for kubevirt API. For CRC it will be `6443`.
 - `namspace` - Namespace where the VM is.
 - `name` - Name of the VM.
-- `token` - Token generated using the `/token` endpoint.
+- `token` - Token returned by `vm-console-proxy`.
 
 For example, the following URL will point the client to a VM after substituting variables:
 ```

--- a/example-client/index.html
+++ b/example-client/index.html
@@ -160,7 +160,8 @@
             url,
             {
                 wsProtocols: [
-                    "base64url.bearer.authorization.k8s.io." + vncToken,
+                    // The token needs to be base64 encoded
+                    "base64url.bearer.authorization.k8s.io." + btoa(vncToken),
                     "base64.binary.k8s.io"
                 ]
             }


### PR DESCRIPTION
**What this PR does / why we need it**:
The token that is needs to be base64 encoded.

**Release note**:
```release-note
None
```
