### PR TITLE
docs: Add information about "duration" API parameter

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -10,7 +10,14 @@ Where `${VMI_NAMESPACE}` and `${VMI_NAME}` are the namespace
 and name of a running VMI.
 
 #### Parameters
-- `duration` - Duration while the token is valid
+- `duration` - Duration while the token is valid. If it is not specified, then the token will expire after 10 minutes.
+  The minimum `duration` value is 10 minutes, and there isn't a maximum value.
+  Its format is described in the golang library documentation [here](https://pkg.go.dev/time@go1.19.13#ParseDuration):
+
+> A duration string is a possibly signed sequence of
+> decimal numbers, each with optional fraction and a unit suffix,
+> such as `300ms`, `-1.5h` or `2h45m`.
+> Valid time units are `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`.
 
 #### Result
 Result is a JSON object containing the token:


### PR DESCRIPTION
**What this PR does / why we need it**:
Added more information about the `duration` parameter.

**Release note**:
```release-note
None
```
