### PR TITLE
feat: configure dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,28 +6,18 @@ updates:
       interval: "daily"
     allow:
       - dependency-type: "all"
-  - package-ecosystem: "gomod"
-    directory: "/"
-    target-branch: "release-v0.3"
-    schedule:
-      interval: "daily"
-    allow:
-      - dependency-type: "all"
-  - package-ecosystem: "gomod"
-    directory: "/"
-    target-branch: "release-v0.2"
-    schedule:
-      interval: "daily"
-    allow:
-      - dependency-type: "all"
-  - package-ecosystem: "gomod"
-    directory: "/"
-    target-branch: "release-v0.1"
-    schedule:
-      interval: "daily"
-    allow:
-      - dependency-type: "all"
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+      development-dependencies:
+        dependency-type: "development"
+    open-pull-requests-limit: 3
+    labels:
+      - "release-note-none"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"  
+    open-pull-requests-limit: 3
+    labels:
+      - "release-note-none"


### PR DESCRIPTION
**What this PR does / why we need it**:
remove configuration for release branches, keep config only for main branch.
Reduce number of PRs to max 3.
Enable grouping of dependencies to a single PR.
Add release-note-none label

**Release note**:
```
NONE
```
