### PR TITLE
chore: Remove unused RBAC permission

### DIFF
--- a/manifests/role.yaml
+++ b/manifests/role.yaml
@@ -5,14 +5,6 @@ metadata:
   name: vm-console-proxy
 rules:
 - apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
   - kubevirt.io
   resources:
   - virtualmachineinstances


### PR DESCRIPTION
**What this PR does / why we need it**:
Permission to access pods is not needed any more.

**Release note**:
```release-note
None
```
