### PR TITLE
docs: Improve API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,8 @@ kubectl apply -f "https://github.com/kubevirt/vm-console-proxy/releases/latest/d
 
 ## API
 See the [API documentation](docs/api.md).
+
+### API Access Permissions
+
+The `token.kubevirt.io:generate` `ClusterRole` can be bound to users or service accounts to give
+them permission to call the API.

--- a/docs/api.md
+++ b/docs/api.md
@@ -44,4 +44,8 @@ KUBERNETES_USER_TOKEN=$(oc whoami -t)
 ### Revoking a token
 Revoking a single token is not possible. 
 All tokens associated with a VM can be revoked by deleting the `ServiceAccount` that was created for generating them.
-It is in the same namespace as the VM, its name is `${VM_NAME}-vnc-access`, and it has `ownerReference` set to the VM. 
+It is in the same namespace as the VM, its name is `${VM_NAME}-vnc-access`, and it has `ownerReference` set to the VM.
+
+```bash
+kubectl delete serviceaccount --namespace "${VM_NAMESPACE}" "${VM_NAME}-vnc-access"
+```


### PR DESCRIPTION

**What this PR does / why we need it**:
- Mentions the `ClusterRole` that can give users access to the API.
- Added an example `kubectl` command to delete `ServiceAccount` and revoke tokens.

Related: https://issues.redhat.com/browse/CNV-38641

**Release note**:
```release-note
Improved API documentation.
```
