### PR TITLE
chore: Remove irrelevant comment

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	k8s.io/client-go v12.0.0+incompatible
 	k8s.io/utils v0.0.0-20240102154912-e7106e64919e
 	kubevirt.io/api v1.1.1
-	kubevirt.io/client-go v1.2.0-rc.1 // TODO: update to a tag, once it is released
+	kubevirt.io/client-go v1.2.0-rc.1
 	sigs.k8s.io/yaml v1.4.0
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The tag for `kubevirt.io/client-go` was created.

**Release note**:
```release-note
None
```
