### PR TITLE
chore: Disable dependabot because it needs update to golang 1.22

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,23 +1,24 @@
+# TODO: Enable dependabot again when we update to golang 1.22 in downstream
 version: 2
-updates:
-  - package-ecosystem: "gomod"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    allow:
-      - dependency-type: "all"
-    groups:
-      production-dependencies:
-        dependency-type: "production"
-      development-dependencies:
-        dependency-type: "development"
-    open-pull-requests-limit: 3
-    labels:
-      - "release-note-none"
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"  
-    open-pull-requests-limit: 3
-    labels:
-      - "release-note-none"
+updates: []
+#  - package-ecosystem: "gomod"
+#    directory: "/"
+#    schedule:
+#      interval: "daily"
+#    allow:
+#      - dependency-type: "all"
+#    groups:
+#      production-dependencies:
+#        dependency-type: "production"
+#      development-dependencies:
+#        dependency-type: "development"
+#    open-pull-requests-limit: 3
+#    labels:
+#      - "release-note-none"
+#  - package-ecosystem: "github-actions"
+#    directory: "/"
+#    schedule:
+#      interval: "weekly"
+#    open-pull-requests-limit: 3
+#    labels:
+#      - "release-note-none"


### PR DESCRIPTION
**What this PR does / why we need it**:
We are waiting until downstream supports golang 1.22, then we can update upstream.

**Release note**:
```release-note
None
```
