### PR TITLE
fix: enable KUBECONFIG default for functest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@ KUSTOMIZE ?= $(LOCALBIN)/kustomize
 KUSTOMIZE_VERSION ?= v4.5.7
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 
+KUBECONFIG ?= ~/.kube/config
+
 .PHONY:build
 build: fmt vet
 	go build -o bin/console main.go
@@ -56,7 +58,7 @@ test:
 
 .PHONY: functest
 functest:
-	go test -v -timeout 0 -count 1 ./tests/...
+	KUBECONFIG=$(KUBECONFIG) go test -v -timeout 0 -count 1 ./tests/...
 
 .PHONY: fmt
 fmt:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: enable KUBECONFIG default for functest

**Which issue(s) this PR fixes**: 
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note NONE

```
