### PR TITLE
feat: build multi-architecture images in by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,36 +1,42 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal as builder
+# Build this Dockerfile using the command: make build-container
+#
+# This multi-stage image approach prevents issues related to cached builder images,
+# which may be incompatible due to different architectures, potentially slowing down or breaking the build process.
+#
+# By utilizing Go cross-compilation, we can build the target Go binary from the host architecture
+# and then copy it to the target image with the desired architecture.
 
-# create enviroment variables and files
-ENV ENVFILE=/tmp/envfile
-RUN echo "export ARCH=`uname -m | sed 's/x86_64/amd64/'`" >> ${ENVFILE}
+ARG TARGET_ARCH=amd64
+FROM registry.access.redhat.com/ubi9/ubi-minimal as builder
+ARG TARGET_ARCH
+
+# download packages
+RUN microdnf install -y make tar gzip which && microdnf clean all
+RUN export ARCH=$(uname -m | sed 's/x86_64/amd64/'); curl -L https://go.dev/dl/go1.22.4.linux-${ARCH}.tar.gz | tar -C /usr/local -xzf -
+
+# create enviroment variables
 ENV PATH=$PATH:/usr/local/go/bin
 
-RUN microdnf install -y make tar gzip which && microdnf clean all
-
-RUN . ${ENVFILE}; curl -L https://go.dev/dl/go1.22.4.linux-${ARCH}.tar.gz | tar -C /usr/local -xzf -
-
+# copy the Go Modules manifests and vendor directory
 WORKDIR /workspace
-# Copy the Go Modules manifests and vendor directory
 COPY go.mod go.mod
 COPY go.sum go.sum
 COPY vendor/ vendor/
 
-# Copy the go source
+# copy the go source
 COPY Makefile Makefile
 COPY main.go main.go
 COPY api/ api/
 COPY pkg/ pkg/
 
-# Build
-RUN . ${ENVFILE}; CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} GO111MODULE=on make build
+# compile for the TARGET_ARCH
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGET_ARCH} make build
 
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM --platform=linux/${TARGET_ARCH} registry.access.redhat.com/ubi9/ubi-micro
 
-RUN microdnf update -y && microdnf clean all
-
+# copy binary from builder image
 WORKDIR /
 COPY --from=builder /workspace/bin/console .
 USER 1000
-
 ENTRYPOINT ["/console"]

--- a/Makefile
+++ b/Makefile
@@ -24,11 +24,14 @@ build: fmt vet
 
 .PHONY: build-container
 build-container: fmt vet test
-	podman build -t ${IMG} .
+	podman manifest rm ${IMG} || true && \
+	podman build --build-arg TARGET_ARCH=amd64 --manifest=${IMG} . && \
+	podman build --build-arg TARGET_ARCH=s390x --manifest=${IMG} . && \
+	podman build --build-arg TARGET_ARCH=arm64 --manifest=${IMG} .
 
 .PHONY: push-container
 push-container:
-	podman push ${IMG}
+	podman manifest push ${IMG}
 
 .PHONY: manifests
 manifests:


### PR DESCRIPTION
This feature utilizes cross-compiling to generate binary files for the amd64 and s390x architectures, followed by the creation of images for both architectures.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: multiarch images enablement

**Which issue(s) this PR fixes**: 
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note NONE

```
