### PR TITLE
fix: correctly handle empty ciphers in TLS config file

### DIFF
--- a/api/v1/types.go
+++ b/api/v1/types.go
@@ -12,7 +12,7 @@ type TokenResponse struct {
 
 // TlsProfile is the TLS configuration for the proxy.
 type TlsProfile struct {
-	Ciphers       []string           `json:"ciphers,omitempty"`
+	Ciphers       []string           `json:"ciphers"`
 	MinTLSVersion TLSProtocolVersion `json:"minTLSVersion,omitempty"`
 }
 

--- a/pkg/console/tlsconfig/tlsconfig_test.go
+++ b/pkg/console/tlsconfig/tlsconfig_test.go
@@ -125,7 +125,7 @@ var _ = Describe("TlsConfig", func() {
 		Expect(config.MinVersion).To(Equal(uint16(tls.VersionTLS12)))
 	})
 
-	It("should use default ciphers, if ciphers are not sepcified", func() {
+	It("should use default ciphers, if ciphers are not specified", func() {
 		tlsConfig := &v1.TlsProfile{
 			MinTLSVersion: v1.VersionTLS12,
 		}
@@ -140,6 +140,25 @@ var _ = Describe("TlsConfig", func() {
 
 		// Testing for nil specifically, because nil means default configuration.
 		Expect(config.CipherSuites).To(BeNil())
+		Expect(config.MinVersion).To(Equal(uint16(tls.VersionTLS12)))
+	})
+
+	It("should use no ciphers if ciphers is an empty array", func() {
+		tlsConfig := &v1.TlsProfile{
+			Ciphers:       []string{},
+			MinTLSVersion: v1.VersionTLS12,
+		}
+		tlsConfigYaml, err := yaml.Marshal(tlsConfig)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(os.WriteFile(tlsConfigPath, tlsConfigYaml, 0666)).To(Succeed())
+
+		configWatch.Reload()
+
+		config, err := configWatch.GetConfig()
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(config.CipherSuites).ToNot(BeNil())
+		Expect(config.CipherSuites).To(BeEmpty())
 		Expect(config.MinVersion).To(Equal(uint16(tls.VersionTLS12)))
 	})
 

--- a/vendor/kubevirt.io/vm-console-proxy/api/v1/types.go
+++ b/vendor/kubevirt.io/vm-console-proxy/api/v1/types.go
@@ -12,7 +12,7 @@ type TokenResponse struct {
 
 // TlsProfile is the TLS configuration for the proxy.
 type TlsProfile struct {
-	Ciphers       []string           `json:"ciphers,omitempty"`
+	Ciphers       []string           `json:"ciphers"`
 	MinTLSVersion TLSProtocolVersion `json:"minTLSVersion,omitempty"`
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The `ciphers` field in the TLS config file has different meaning if it is `Null` or an empty array `[]`.

- `Null` means that we should enable default cipher suites.
- Empty array `[]` means that we don't want to enable any cipher suites. Cipher suites for TLS 1.3 cannot be configured, so they are still enabled, even if empty array is passed.

**Release note**:
```release-note
The "ciphers" field in the TLS config file has different meaning if it is "Null" or an empty array "[]".
```
