### PR TITLE
chore: remove opokornyy from reviewers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -8,4 +8,3 @@ reviewers:
   - ksimon1
   - lyarwood
   - jcanocan
-  - opokornyy


### PR DESCRIPTION
**What this PR does / why we need it**:
Removed `opokornyy` from the `OWNERS` file

**Release note**:
```release-note
None
```
