### PR TITLE
chore: Disable release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,8 +1,14 @@
 name: Release
 
-on:
-  release:
-    types: [published]
+# Disabling this workflow, because these actions are not allowed:
+#  bruceadams/get-release, peter-evans/repository-dispatch
+# TODO: fix this workflow
+
+#on:
+#  release:
+#    types: [published]
+
+on: {}
 
 jobs:
   build:


### PR DESCRIPTION
**What this PR does / why we need it**:
The workflow uses actions that are not allowed.
Temporarily disabling the workflow.


**Release note**:
```release-note
None
```
