### PR TITLE
chore: Update golang version to 1.23.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ARG TARGET_ARCH
 
 # download packages
 RUN microdnf install -y make tar gzip which && microdnf clean all
-RUN export ARCH=$(uname -m | sed 's/x86_64/amd64/'); curl -L https://go.dev/dl/go1.22.4.linux-${ARCH}.tar.gz | tar -C /usr/local -xzf -
+RUN export ARCH=$(uname -m | sed 's/x86_64/amd64/'); curl -L https://go.dev/dl/go1.23.2.linux-${ARCH}.tar.gz | tar -C /usr/local -xzf -
 
 # create enviroment variables
 ENV PATH=$PATH:/usr/local/go/bin

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module kubevirt.io/vm-console-proxy/api
 
-go 1.22.4
+go 1.23.2
 
 require k8s.io/apimachinery v0.30.3
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module kubevirt.io/vm-console-proxy
 
-go 1.22.4
+go 1.23.2
 
 require (
 	github.com/emicklei/go-restful/v3 v3.12.1

--- a/renovate.json
+++ b/renovate.json
@@ -23,7 +23,7 @@
        "release-note-none"
     ],
     "constraints": {
-      "go": "1.22",
+      "go": "1.23",
       "matchBaseBranches":[
          "main"
       ]

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -697,7 +697,7 @@ kubevirt.io/containerized-data-importer-api/pkg/apis/upload/v1beta1
 ## explicit; go 1.17
 kubevirt.io/controller-lifecycle-operator-sdk/api
 # kubevirt.io/vm-console-proxy/api v0.0.0 => ./api
-## explicit; go 1.22.4
+## explicit; go 1.23.2
 kubevirt.io/vm-console-proxy/api/v1
 # sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd
 ## explicit; go 1.18


### PR DESCRIPTION
**What this PR does / why we need it**:
Updated golang version to 1.23.2

**Release note**:
```release-note
None
```
