### PR TITLE
fix: regex in renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
       ":gitSignOff",
       ":dependencyDashboard"
    ],
-   "baseBranches": ["main", "/release-v([0-9]+\\.([0-9]+))/"],
+   "baseBranches": ["main", "/^release-v([0-9]+\\.([0-9]+))$/"],
    "prConcurrentLimit": 3,
    "lockFileMaintenance": {
       "enabled": false


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: regex in renovate config

previous regex caused Renovate to evaluate branches created by renovate as matching. To fix this, the ^ and $ are added to the regex.

**Release note**:
```
NONE
```
