### PR TITLE
fix: example-client: Change subprotocol to what kubevirt expects

### DIFF
--- a/example-client/index.html
+++ b/example-client/index.html
@@ -169,7 +169,7 @@
                 wsProtocols: [
                     // The token needs to be base64 encoded
                     "base64url.bearer.authorization.k8s.io." + base64urlEncode(vncToken),
-                    "base64.binary.k8s.io"
+                    "plain.kubevirt.io"
                 ]
             }
         );


### PR DESCRIPTION
**What this PR does / why we need it**:
Kubevirt websocket endpoints expect different subprotocol than kubenetes endpoints.

Here is the definition of the subprotocol with documentation: https://github.com/kubevirt/kubevirt/blob/0acbdb417a0f7721fca9b73bd4be97391bd0ed54/staging/src/kubevirt.io/client-go/subresources/constants.go#L22-L25

**Release note**:
```release-note
None
```
