### PR TITLE
chore: Rename port name according to best practices

### DIFF
--- a/manifests/deployment.yaml
+++ b/manifests/deployment.yaml
@@ -34,7 +34,7 @@ spec:
               memory: "65Mi"
               cpu: "100m"
           ports:
-            - name: api
+            - name: http-api
               protocol: TCP
               containerPort: 8768
           securityContext:

--- a/manifests/service.yaml
+++ b/manifests/service.yaml
@@ -7,6 +7,6 @@ metadata:
 spec:
   ports:
     - port: 443
-      targetPort: api
+      targetPort: http-api
   selector:
     vm-console-proxy.kubevirt.io: vm-console-proxy


### PR DESCRIPTION
**What this PR does / why we need it**:
The name should have protocol prefix.
https://redhat-best-practices-for-k8s.github.io/guide/#k8s-best-practices-requirements-cnf-reqs

**Which issue(s) this PR fixes**: 
Jira: https://issues.redhat.com/browse/CNV-67392

**Release note**:
```release-note
None
```
