### PR TITLE
tests: fix VM cleanup functest timeout and drop deprecated spec.running

### DIFF
--- a/tests/proxy_test.go
+++ b/tests/proxy_test.go
@@ -20,7 +20,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
 	kubevirtcorev1 "kubevirt.io/api/core/v1"
 
 	api "kubevirt.io/vm-console-proxy/api/v1"
@@ -190,7 +189,7 @@ var _ = Describe("Kubevirt proxy", func() {
 				Eventually(func() error {
 					_, err := ApiClient.VirtualMachine(testNamespace).Get(context.Background(), vmName, metav1.GetOptions{})
 					return err
-				}, time.Minute, time.Second).Should(MatchError(errors.IsNotFound, "errors.IsNotFound"))
+				}, 2*time.Minute, time.Second).Should(MatchError(errors.IsNotFound, "errors.IsNotFound"))
 
 				By("testing that resources have been cleaned up")
 				_, err = ApiClient.CoreV1().ServiceAccounts(testNamespace).Get(context.Background(), resourceName, metav1.GetOptions{})
@@ -208,7 +207,7 @@ var _ = Describe("Kubevirt proxy", func() {
 	Context("accessing kubevirt VMI/vnc endpoint", func() {
 		It("should be able to access VMI/vnc endpoint using token", func() {
 			vm := testVm("test-vm-")
-			vm.Spec.Running = pointer.Bool(false)
+			vm.Spec.RunStrategy = ptr.To(kubevirtcorev1.RunStrategyHalted)
 			vm, err := ApiClient.VirtualMachine(testNamespace).Create(context.Background(), vm, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
@@ -288,7 +287,7 @@ func testVm(namePrefix string) *kubevirtcorev1.VirtualMachine {
 			Namespace:    testNamespace,
 		},
 		Spec: kubevirtcorev1.VirtualMachineSpec{
-			Running: ptr.To(true),
+			RunStrategy: ptr.To(kubevirtcorev1.RunStrategyAlways),
 			Template: &kubevirtcorev1.VirtualMachineInstanceTemplateSpec{
 				Spec: kubevirtcorev1.VirtualMachineInstanceSpec{
 					Domain: kubevirtcorev1.DomainSpec{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Running VM teardown on real clusters can exceed one minute. Wait up to two minutes for the VM to disappear before asserting OwnerReference cleanup.

Use spec.runStrategy instead of deprecated spec.running in test VMs.

**Which issue(s) this PR fixes**: 
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes #

**Special notes for your reviewer**:
Fixes warnings and timeout seen while running  `make functest ` on a local cluster.

`Before fix`

•••••••W0626 05:51:01.464788 1353092 warnings.go:70] spec.running is deprecated, please use spec.runStrategy instead.
•W0626 05:51:02.735486 1353092 warnings.go:70] spec.running is deprecated, please use spec.runStrategy instead.
•W0626 05:51:03.992854 1353092 warnings.go:70] spec.running is deprecated, please use spec.runStrategy instead.

Summarizing 1 Failure:
  [FAIL] Kubevirt proxy /token endpoint with VM [It] should cleanup when VM is deleted
  <>/vm-console-proxy/tests/proxy_test.go:193

`After fix`

Tests passed after this change:
Ran 15 of 15 Specs in 19.623 seconds
SUCCESS! -- 15 Passed | 0 Failed | 0 Pending | 0 Skipped

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
